### PR TITLE
feat(SnippetText): Implement textarea and full-width styling

### DIFF
--- a/src/app/components/snippet-text/snippet-text.html
+++ b/src/app/components/snippet-text/snippet-text.html
@@ -1,4 +1,3 @@
 <div class="snippet-text-container">
-  <p>This is a <strong>Text Snippet</strong>. Editable content would go here.</p>
-  <!-- Example: <textarea placeholder="Enter your text..."></textarea> -->
+  <textarea placeholder="Enter your text..."></textarea>
 </div>

--- a/src/app/components/snippet-text/snippet-text.sass
+++ b/src/app/components/snippet-text/snippet-text.sass
@@ -3,5 +3,14 @@
   padding: 10px
   margin: 5px
   background-color: #f9f9f9
-  width: 90%
+  width: 100%
+  height: 100% // Added to make the container itself take full height
   box-sizing: border-box
+
+  textarea
+    width: 100%
+    height: 100%
+    box-sizing: border-box
+    border: none // Optional: removes default textarea border
+    resize: none // Optional: removes resize handle
+    padding: 5px // Optional: adds some internal padding to the textarea


### PR DESCRIPTION
I've implemented a textarea within the SnippetText component to allow your input. I've also updated the component's styles so that both the main container and the textarea occupy 100% of the available width and height of their parent element.

Here's a summary of the changes:
- I modified `snippet-text.html` to replace the placeholder paragraph with a `textarea` element.
- I updated `snippet-text.sass`:
    - Set `width` and `height` of `.snippet-text-container` to `100%`.
    - Added styles for the `textarea` to also have `width: 100%` and `height: 100%`.
    - Ensured `box-sizing: border-box` for both elements for correct sizing.
    - Removed default textarea border and resize handle for a cleaner look.