### PR TITLE
feat: Implement SnippetCompute component

### DIFF
--- a/src/app/components/snippet-compute/snippet-compute.html
+++ b/src/app/components/snippet-compute/snippet-compute.html
@@ -1,4 +1,4 @@
 <div class="snippet-compute-container">
-  <p>This is a <strong>Compute Snippet</strong>. Calculation logic and results would be displayed here.</p>
-  <!-- Example: <input type="text" placeholder="Enter expression..."><button>Compute</button><div>Result: ...</div> -->
+  <textarea [(ngModel)]="snippetCode" (ngModelChange)="onSnippetChange()" placeholder="Enter your script here..."></textarea>
+  <button [disabled]="isPlayButtonDisabled">Play</button>
 </div>

--- a/src/app/components/snippet-compute/snippet-compute.sass
+++ b/src/app/components/snippet-compute/snippet-compute.sass
@@ -1,7 +1,32 @@
 .snippet-compute-container
-  border: 1px dashed #add
-  padding: 10px
-  margin: 5px
-  background-color: #f0f9f9
-  width: 90%
+  display: flex
+  flex-direction: column
+  height: 100%
+  width: 100% // Ensure it takes full width of its parent
+  padding: 10px // Optional padding
   box-sizing: border-box
+
+  textarea
+    flex-grow: 1 // Allows textarea to take available vertical space
+    width: 100% // Take full width
+    margin-bottom: 10px // Space before the button
+    // Add other styling as needed, e.g., resize: none;
+    font-family: monospace // Good for code
+    border: 1px solid #ccc // Basic border
+    padding: 8px // Padding inside textarea
+
+  button
+    // Style for the button
+    padding: 10px 15px
+    background-color: #007bff // Example primary color
+    color: white
+    border: none
+    border-radius: 4px
+    cursor: pointer
+
+    &:disabled
+      background-color: #ccc // Disabled state color
+      cursor: not-allowed
+
+    &:hover:not(:disabled)
+      background-color: #0056b3 // Darker on hover when enabled

--- a/src/app/components/snippet-compute/snippet-compute.ts
+++ b/src/app/components/snippet-compute/snippet-compute.ts
@@ -1,13 +1,88 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common'; // Good practice for standalone components
+import { FormsModule } from '@angular/forms'; // Required for ngModel
+
+export const VALID_INTERPRETERS = [
+  'bash',
+  'ksh',
+  'zsh',
+  'csh',
+  'tcsh',
+  'python3',
+  'perl',
+  'ruby',
+  'node',
+  'ts-node',
+  'php',
+  'java',
+  'groovy',
+  'lua5.4',
+  'R',
+  'gawk',
+  'tcl',
+  'expect',
+];
 
 @Component({
   selector: 'app-snippet-compute',
   standalone: true, // Ensure it is standalone
-  imports: [CommonModule], // Add CommonModule
+  imports: [CommonModule, FormsModule], // Add CommonModule and FormsModule
   templateUrl: './snippet-compute.html',
   styleUrl: './snippet-compute.sass'
 })
 export class SnippetCompute {
+  snippetCode: string = '';
+  isPlayButtonDisabled: boolean = true;
 
+  onSnippetChange(): void {
+    if (!this.snippetCode) {
+      this.isPlayButtonDisabled = true;
+      return;
+    }
+
+    const lines = this.snippetCode.split('\\n');
+    const firstLine = lines[0];
+
+    if (!firstLine.startsWith('#!')) {
+      this.isPlayButtonDisabled = true;
+      return;
+    }
+
+    // Extracts interpreter, optionally ignoring path like /bin/ or /usr/bin
+    // e.g. #!/usr/bin/python3 -> python3
+    // e.g. #!bash -> bash
+    // The first line should strictly be the shebang and interpreter, nothing else.
+    const shebangMatch = firstLine.match(/^#!(?:\/(?:usr\/)?bin\/)?([a-zA-Z0-9._-]+)$/);
+
+    if (shebangMatch && shebangMatch[1]) {
+      const interpreter = shebangMatch[1];
+      // Check if the snippet has more than just the shebang line OR if the shebang line is the entire snippet code (e.g. "#!bash" is not enough, needs a newline)
+      // However, snippetCode is the full content. If split by \n, firstLine is correct.
+      // The requirement "and then a newline character" is implicitly handled if lines.length > 1 or if snippetCode ends with \n.
+      // For a single line snippet like "#!bash", it's valid if it's intended to be executed as such.
+      // The prompt example "#!/bin/bash\n" suggests the newline is significant.
+      // If snippetCode is just "#!bash", then lines.length is 1.
+      // If snippetCode is "#!bash\n", then lines will be ["#!bash", ""].
+      // The problem seems to imply that the script itself must have a newline after the shebang.
+      // This means `this.snippetCode` must contain a `\n` after the first line.
+
+      const isValidInterpreter = VALID_INTERPRETERS.includes(interpreter);
+      if (isValidInterpreter) {
+        // Check if there's a newline after the first line, or if the first line is the only content and it doesn't end with \n.
+        // A script is valid if it's `#!interpreter\n...` or `#!interpreter\n`
+        // A script is not valid if it's just `#!interpreter`
+        if (this.snippetCode.includes('\\n')) {
+             this.isPlayButtonDisabled = false;
+        } else {
+            // If there's no newline at all in the snippet code, it means it's a single line like "#!bash"
+            // This is considered invalid by the prompt's examples like "#!/bin/bash\n"
+            this.isPlayButtonDisabled = true;
+        }
+      } else {
+        this.isPlayButtonDisabled = true;
+      }
+    } else {
+      this.isPlayButtonDisabled = true;
+    }
+  }
 }


### PR DESCRIPTION
Adds a new Angular component `SnippetCompute` that allows you to input code snippets into a text area.

Features:
- Recognizes shebang lines (e.g., `#!/bin/bash `, `#!python3
`) from a predefined list of interpreters.
- Enables a "Play" button if a valid shebang and a newline are detected at the beginning of the snippet.
- The component is styled to occupy the full available space of its container using flexbox.
- Includes `FormsModule` for `ngModel` functionalities.

Unit tests have been written for the component's logic, covering valid and invalid snippet headers and button states. However, I couldn't run these tests in the development environment due to a Node.js version incompatibility (the environment has v18.19.1, but the project requires v20.19+ or v22.12+). The tests are located in `src/app/components/snippet-compute/snippet-compute.spec.ts` and should be run in a compatible environment.

The list of supported interpreters includes: bash, ksh, zsh, csh, tcsh, python3, perl, ruby, node, ts-node, php, java, groovy, lua5.4, R, gawk, tcl, expect.