### PR TITLE
feat: Apply min-width to snippet components

### DIFF
--- a/src/app/components/snippet-compute/snippet-compute.sass
+++ b/src/app/components/snippet-compute/snippet-compute.sass
@@ -3,6 +3,7 @@
   flex-direction: column
   height: 100%
   width: 100% // Ensure it takes full width of its parent
+  min-width: 450px
   padding: 10px // Optional padding
   box-sizing: border-box
 

--- a/src/app/components/snippet-text/snippet-text.sass
+++ b/src/app/components/snippet-text/snippet-text.sass
@@ -3,6 +3,7 @@
   padding: 10px
   margin: 5px
   background-color: #f9f9f9
+  min-width: 450px
   width: 100%
   height: 100% // Added to make the container itself take full height
   box-sizing: border-box


### PR DESCRIPTION
Applied `min-width: 450px` to both `snippet-text` and `snippet-compute` components.

The `.snippet-text-container` class in `src/app/components/snippet-text/snippet-text.sass` and the `.snippet-compute-container` class in `src/app/components/snippet-compute/snippet-compute.sass` were modified to include this `min-width`.

The textareas within these components are set to `width: 100%`, ensuring they adapt to the new minimum width of their parent containers.