### PR TITLE
Fix: Ensure getTayloredBlock returns XMLDocument and Sheet instantiat…

### DIFF
--- a/src/app/components/sheet/sheet.spec.ts
+++ b/src/app/components/sheet/sheet.spec.ts
@@ -193,4 +193,68 @@ describe('SheetComponent', () => {
 
     expect(component.saveSheet).toHaveBeenCalled();
   });
+
+  describe('addSnippet method direct tests', () => {
+    // Import SnippetText and SnippetCompute to use instanceof
+    let SnippetTextType: typeof import('../snippet-text/snippet-text').SnippetText;
+    let SnippetComputeType: typeof import('../snippet-compute/snippet-compute').SnippetCompute;
+
+    beforeAll(async () => {
+      SnippetTextType = (await import('../snippet-text/snippet-text')).SnippetText;
+      SnippetComputeType = (await import('../snippet-compute/snippet-compute')).SnippetCompute;
+    });
+
+    beforeEach(() => {
+      // Reset snippets before each test in this block
+      component.snippets = [];
+      // Reset nextId if necessary, though component.addSnippet handles its increment
+      // (Reflection: component internal 'nextId' is not reset here, which is fine as it mimics continuous use)
+    });
+
+    it('should add an instance of SnippetText when type is "text"', () => {
+      component.addSnippet('text');
+      expect(component.snippets.length).toBe(1);
+      const newSnippet = component.snippets[0];
+      expect(newSnippet).toBeInstanceOf(SnippetTextType);
+      expect(newSnippet.type).toBe('text');
+      expect(newSnippet.id).toBeDefined(); // ID should be assigned
+    });
+
+    it('should add an instance of SnippetCompute when type is "compute"', () => {
+      component.addSnippet('compute');
+      expect(component.snippets.length).toBe(1);
+      const newSnippet = component.snippets[0];
+      expect(newSnippet).toBeInstanceOf(SnippetComputeType);
+      expect(newSnippet.type).toBe('compute');
+      expect(newSnippet.id).toBeDefined(); // ID should be assigned
+    });
+
+    it('should assign unique IDs to subsequently added snippets', () => {
+      component.addSnippet('text'); // First snippet
+      component.addSnippet('compute'); // Second snippet
+      expect(component.snippets.length).toBe(2);
+      expect(component.snippets[0].id).not.toBe(component.snippets[1].id);
+    });
+
+    it('should ensure snippets added via addSnippet have a callable getTayloredBlock method returning XMLDocument', () => {
+      // Test for 'text' snippet
+      component.addSnippet('text');
+      let textSnippet = component.snippets[0];
+      expect(typeof textSnippet.getTayloredBlock).toBe('function');
+      let textXmlDoc = textSnippet.getTayloredBlock();
+      expect(textXmlDoc).toBeInstanceOf(XMLDocument);
+      expect(textXmlDoc.documentElement.tagName).toBe('taylored');
+      expect(textXmlDoc.documentElement.getAttribute('text')).toBe('true');
+
+      // Reset for compute snippet (or use a new component instance for isolation)
+      component.snippets = [];
+      component.addSnippet('compute');
+      let computeSnippet = component.snippets[0];
+      expect(typeof computeSnippet.getTayloredBlock).toBe('function');
+      let computeXmlDoc = computeSnippet.getTayloredBlock();
+      expect(computeXmlDoc).toBeInstanceOf(XMLDocument);
+      expect(computeXmlDoc.documentElement.tagName).toBe('taylored');
+      expect(computeXmlDoc.documentElement.getAttribute('compute')).toBeTruthy();
+    });
+  });
 });

--- a/src/app/components/sheet/sheet.ts
+++ b/src/app/components/sheet/sheet.ts
@@ -24,7 +24,18 @@ export class Sheet {
   private nextId = 0;
 
   addSnippet(type: 'text' | 'compute'): void {
-    this.snippets.push({ id: this.nextId++, type: type });
+    let newSnippet: Snippet;
+    const currentId = this.nextId++;
+
+    if (type === 'text') {
+      newSnippet = new SnippetText();
+    } else { // type === 'compute'
+      newSnippet = new SnippetCompute();
+    }
+
+    newSnippet.id = currentId;
+    // The 'type' property is already set in the respective class constructors/definitions.
+    this.snippets.push(newSnippet);
   }
   removeSnippet(id: number): void {
     this.snippets = this.snippets.filter(snippet => snippet.id !== id);

--- a/src/app/components/snippet-compute/snippet-compute.ts
+++ b/src/app/components/snippet-compute/snippet-compute.ts
@@ -48,10 +48,11 @@ export class SnippetCompute implements Snippet {
   @Input() id!: number;
   @Output() empty = new EventEmitter<number>();
 
-  getTayloredBlock(): string {
+  getTayloredBlock(): XMLDocument {
     const timestamp = Date.now().toString();
     const encodedTimestamp = btoa(timestamp);
-    return `<taylored number="${this.id}" compute="${encodedTimestamp}">${this.snippetCode}</taylored>`;
+    const xmlString = `<taylored number="${this.id}" compute="${encodedTimestamp}">${this.snippetCode}</taylored>`;
+    return new DOMParser().parseFromString(xmlString, "text/xml");
   }
 
   onSnippetChange(): void {

--- a/src/app/components/snippet-text/snippet-text.spec.ts
+++ b/src/app/components/snippet-text/snippet-text.spec.ts
@@ -27,4 +27,49 @@ describe('SnippetTextComponent', () => {
     expect(textAreaElement).toBeTruthy(); // Check if the textarea exists
     expect(textAreaElement.placeholder).toContain('Enter your text...'); // Check its placeholder
   });
+
+  describe('getTayloredBlock method', () => {
+    beforeEach(() => {
+      // Set default values for id and text for these tests
+      component.id = 789;
+      component.text = 'This is some sample text.';
+      // fixture.detectChanges(); // Not strictly necessary for method testing
+    });
+
+    it('should return an XMLDocument', () => {
+      const result = component.getTayloredBlock();
+      expect(result).toBeInstanceOf(XMLDocument);
+    });
+
+    it('should return an XMLDocument with the correct structure and content', () => {
+      const result = component.getTayloredBlock();
+      expect(result).toBeInstanceOf(XMLDocument);
+
+      const rootElement = result.documentElement;
+      expect(rootElement.tagName).toBe('taylored');
+      expect(rootElement.getAttribute('number')).toBe(component.id.toString());
+      expect(rootElement.getAttribute('text')).toBe('true');
+      expect(rootElement.textContent).toBe(component.text);
+    });
+
+    it('should use the component id in the "number" attribute of the XMLDocument', () => {
+      component.id = 101; // Change id to test
+      const result = component.getTayloredBlock();
+      const rootElement = result.documentElement;
+      expect(rootElement.getAttribute('number')).toBe('101');
+    });
+
+    it('should use the component text as the text content of the XMLDocument', () => {
+      component.text = 'More detailed text for testing purposes.'; // Change text to test
+      const result = component.getTayloredBlock();
+      const rootElement = result.documentElement;
+      expect(rootElement.textContent).toBe('More detailed text for testing purposes.');
+    });
+
+    it('should have a "text" attribute with the value "true"', () => {
+      const result = component.getTayloredBlock();
+      const rootElement = result.documentElement;
+      expect(rootElement.getAttribute('text')).toBe('true');
+    });
+  });
 });

--- a/src/app/components/snippet-text/snippet-text.ts
+++ b/src/app/components/snippet-text/snippet-text.ts
@@ -23,6 +23,11 @@ export class SnippetText implements Snippet {
 
   text: string = '';
 
+  getTayloredBlock(): XMLDocument {
+    const xmlString = `<taylored number="${this.id}" text="true">${this.text}</taylored>`;
+    return new DOMParser().parseFromString(xmlString, "text/xml");
+  }
+
   onTextChange(): void {
     if (this.text.trim() === '') {
       this.empty.emit(this.id);


### PR DESCRIPTION
…es Snippets

- I modified `SnippetCompute.getTayloredBlock` to return an `XMLDocument` by parsing its string output, conforming to the `Snippet` interface.
- I added `getTayloredBlock` to `SnippetText` to also return an `XMLDocument`, ensuring interface conformity. The XML includes the text content and relevant attributes.
- I updated `Sheet.addSnippet` to create full instances of `SnippetText` or `SnippetCompute` (based on type) and assign them an ID. This ensures that the `getTayloredBlock` method is correctly available on snippet objects.
- I added/updated unit tests for `SnippetCompute`, `SnippetText`, and `Sheet` to verify the `getTayloredBlock` implementations and the correct instantiation of snippets in the `Sheet` component.