### PR TITLE
feat(sheet): Implement drag-and-drop reordering for snippets

### DIFF
--- a/src/app/components/sheet/sheet.html
+++ b/src/app/components/sheet/sheet.html
@@ -7,12 +7,14 @@
         <mat-icon>save</mat-icon>
       </button>
     </mat-card-header>
-    <mat-card-content class="sheet-card-content">
+    <mat-card-content class="sheet-card-content"
+                      cdkDropList
+                      (cdkDropListDropped)="drop($event)">
       @if (snippets.length === 0) {
         <p>No snippets added yet. Click a button to add one!</p>
       }
       @for (snippet of snippets; track snippet.id; let i = $index) {
-        <div class="snippet-container">
+        <div class="snippet-container" cdkDrag>
           @switch (snippet.type) {
             @case ('text') {
               <app-snippet-text [id]="snippet.id"

--- a/src/app/components/sheet/sheet.sass
+++ b/src/app/components/sheet/sheet.sass
@@ -1,0 +1,41 @@
+// Styles for Angular CDK Drag and Drop
+
+// Style for the element being dragged (the preview)
+.cdk-drag-preview
+  box-sizing: border-box
+  border-radius: 4px
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12)
+  z-index: 1000 // Ensure it's above other elements
+
+// Style for the placeholder element in the list
+.cdk-drag-placeholder
+  opacity: 0.3
+  border: 1px dashed #ccc
+  background: #f9f9f9
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1)
+
+// Style for the original items in the list while one is being dragged
+.cdk-drop-list-dragging .cdk-drag
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1)
+
+// Add a subtle transition for all cdk-drag elements for smoother animations
+.cdk-drag
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1)
+
+// Basic styling for the snippet container within the sheet, if not already present
+// This ensures that the drag handles are well-defined visually.
+.snippet-container
+  margin-bottom: 10px // Add some space between snippets
+  padding: 5px
+  border: 1px solid transparent // Add a border to define draggable area a bit
+
+  // Optional: Add a hover effect to indicate draggable items
+  &:hover
+    border-color: #eee
+
+// Ensure the drop list itself has some basic styling if needed
+.sheet-card-content
+  min-height: 60px // Give some minimum height for the drop zone to be visible
+  border-radius: 4px // Match other card styling

--- a/src/app/components/sheet/sheet.sass
+++ b/src/app/components/sheet/sheet.sass
@@ -4,9 +4,7 @@
 .cdk-drag-preview
   box-sizing: border-box
   border-radius: 4px
-  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
-              0 8px 10px 1px rgba(0, 0, 0, 0.14),
-              0 3px 14px 2px rgba(0, 0, 0, 0.12)
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12)
   z-index: 1000 // Ensure it's above other elements
 
 // Style for the placeholder element in the list

--- a/src/app/components/sheet/sheet.ts
+++ b/src/app/components/sheet/sheet.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common'; // For *ngFor, *ngIf, etc.
 import { SnippetText } from '../snippet-text/snippet-text';
 import { SnippetCompute } from '../snippet-compute/snippet-compute';
@@ -14,7 +15,7 @@ export interface Snippet {
 
 @Component({
   selector: 'app-sheet',
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, SnippetText, SnippetCompute],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, SnippetText, SnippetCompute, DragDropModule],
   standalone: true,
   templateUrl: './sheet.html',
   styleUrl: './sheet.sass'
@@ -43,5 +44,9 @@ export class Sheet {
 
   saveSheet(): void {
     // TODO: Implement save functionality
+  }
+
+  drop(event: CdkDragDrop<Snippet[]>): void {
+    moveItemInArray(this.snippets, event.previousIndex, event.currentIndex);
   }
 }


### PR DESCRIPTION
This commit introduces the ability for you to reorder text and compute snippets within the sheet component.

The Angular CDK DragDropModule has been utilized to enable this functionality. Changes include:
- Importing `DragDropModule` into the `Sheet` component.
- Modifying the `Sheet` component's template to use `cdkDropList` and `cdkDrag` directives.
- Implementing the `drop` method in the `Sheet` component to handle the reordering logic using `moveItemInArray`.
- Adding CSS styles for visual feedback during drag-and-drop operations, including styles for the drag preview, placeholder, and the items in the list while dragging.

This enhancement allows you to customize the order of snippets in your sheets, providing greater flexibility in content organization.