### PR TITLE
feat: Populate sheet with snippets on menu item click

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -10,7 +10,7 @@
 
 <mat-sidenav-container class="app-sidenav-container">
   <mat-sidenav #sidenav mode="over" position="end">
-    <app-side-menu [menuItems]="sideMenuItems"></app-side-menu>
+    <app-side-menu [menuItems]="sideMenuItems" (snippetsSelected)="onSnippetsSelected($event)"></app-side-menu>
   </mat-sidenav>
   <mat-sidenav-content>
     <app-sheet></app-sheet>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -26,6 +26,60 @@ import { MenuItem } from './components/side-menu/menu-item';
 export class App {
   protected title = 'taylored-snippets-web';
   @ViewChild('sidenav') sidenav!: MatSidenav;
+  @ViewChild(Sheet) sheetComponent!: Sheet;
 
   public sideMenuItems: MenuItem[] = [];
+
+  constructor() {
+    // Sample Snippets
+    const sampleTextSnippet: Snippet = {
+      id: 0, // ID will be managed by SheetComponent when added, but good for structure
+      type: 'text',
+      getTayloredBlock: () => {
+        const doc = new DOMParser().parseFromString('<xml></xml>', 'application/xml');
+        const textBlock = doc.createElement('text_block');
+        textBlock.textContent = 'Sample text snippet content';
+        doc.documentElement.appendChild(textBlock);
+        return doc;
+      },
+      output: 'Initial text output if any'
+    };
+
+    const sampleComputeSnippet: Snippet = {
+      id: 1,
+      type: 'compute',
+      getTayloredBlock: () => {
+        const doc = new DOMParser().parseFromString('<xml></xml>', 'application/xml');
+        const computeBlock = doc.createElement('compute_block');
+        computeBlock.textContent = 'Sample compute snippet logic';
+        doc.documentElement.appendChild(computeBlock);
+        return doc;
+      },
+      output: 'Initial compute output if any'
+    };
+
+    // Sample MenuItems
+    this.sideMenuItems = [
+      {
+        label: 'Menu Item 1 (Text)',
+        snippets: [sampleTextSnippet]
+      },
+      {
+        label: 'Menu Item 2 (Compute)',
+        snippets: [sampleComputeSnippet]
+      },
+      {
+        label: 'Menu Item 3 (Both)',
+        snippets: [sampleTextSnippet, sampleComputeSnippet]
+      },
+      {
+        label: 'Menu Item 4 (Empty)',
+        snippets: []
+      }
+    ];
+  }
+
+  public onSnippetsSelected(snippets: Snippet[]) {
+    this.sheetComponent.populateSnippets(snippets);
+  }
 }

--- a/src/app/components/sheet/sheet.ts
+++ b/src/app/components/sheet/sheet.ts
@@ -50,4 +50,8 @@ export class Sheet {
   drop(event: CdkDragDrop<Snippet[]>): void {
     moveItemInArray(this.snippets, event.previousIndex, event.currentIndex);
   }
+
+  populateSnippets(newSnippets: Snippet[]): void {
+    this.snippets = newSnippets;
+  }
 }

--- a/src/app/components/side-menu/side-menu.html
+++ b/src/app/components/side-menu/side-menu.html
@@ -1,5 +1,5 @@
 <mat-nav-list>
   @for (item of menuItems; track item.label) {
-    <a mat-list-item href="#">{{ item.label }}</a>
+    <button mat-list-item (click)="onItemClick(item)">{{ item.label }}</button>
   }
 </mat-nav-list>

--- a/src/app/components/side-menu/side-menu.ts
+++ b/src/app/components/side-menu/side-menu.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { MatListModule } from '@angular/material/list';
 import { MenuItem } from './menu-item';
+import { Snippet } from '../sheet/sheet';
 
 @Component({
   selector: 'app-side-menu',
@@ -11,4 +12,9 @@ import { MenuItem } from './menu-item';
 })
 export class SideMenuComponent {
   @Input() menuItems: MenuItem[] = [];
+  @Output() snippetsSelected = new EventEmitter<Snippet[]>();
+
+  onItemClick(item: MenuItem) {
+    this.snippetsSelected.emit(item.snippets);
+  }
 }


### PR DESCRIPTION
I've implemented functionality to update the sheet component with a list of snippets when a corresponding menu item is clicked.

Key changes:
- Modified `SideMenuComponent`:
  - Added an `EventEmitter` (`snippetsSelected`) to emit an array of `Snippet` objects.
  - Changed menu items from `<a>` tags to `<button mat-list-item>` to handle click events.
  - On item click, the `snippets` array from the `MenuItem` is emitted.
- Modified `SheetComponent`:
  - Added a public method `populateSnippets(newSnippets: Snippet[])` to replace the current snippets with the provided ones.
- Modified `AppComponent`:
  - Added `@ViewChild` to get a reference to the `SheetComponent`.
  - Implemented `onSnippetsSelected(snippets: Snippet[])` method to receive emitted snippets from `SideMenuComponent`.
  - This method calls `sheetComponent.populateSnippets()` to update the sheet.
  - Connected the `snippetsSelected` event from `<app-side-menu>` to `onSnippetsSelected` method in `app.html`.
- Added sample `MenuItem` data in `app.ts` to demonstrate and test the feature, including menu items with text, compute, combined, and empty snippet lists.
- Verified that the `MenuItem` interface already included the necessary `snippets: Snippet[]` property.