### PR TITLE
feat(sheet): Implement save snippets functionality and conditional bu…

### DIFF
--- a/src/app/components/sheet/sheet.html
+++ b/src/app/components/sheet/sheet.html
@@ -2,9 +2,11 @@
   <mat-card class="sheet-card">
     <mat-card-header class="sheet-card-header">
       <span class="header-spacer"></span>
-      <button mat-icon-button aria-label="Save sheet" (click)="saveSheet()">
-        <mat-icon>save</mat-icon>
-      </button>
+      @if (snippets.length > 0) {
+        <button mat-icon-button aria-label="Save sheet" (click)="saveSheet()">
+          <mat-icon>save</mat-icon>
+        </button>
+      }
     </mat-card-header>
     <mat-card-content class="sheet-card-content"
                       cdkDropList

--- a/src/app/components/sheet/sheet.ts
+++ b/src/app/components/sheet/sheet.ts
@@ -44,7 +44,28 @@ export class Sheet {
   }
 
   saveSheet(): void {
-    // TODO: Implement save functionality
+    if (this.snippets.length === 0) {
+      return;
+    }
+
+    const serializableSnippets = this.snippets.map(snippet => ({
+      id: snippet.id,
+      type: snippet.type,
+      output: snippet.output
+    }));
+
+    const jsonString = JSON.stringify(serializableSnippets, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'snippets.json';
+    document.body.appendChild(anchor); // Required for Firefox
+    anchor.click();
+    document.body.removeChild(anchor); // Clean up
+
+    URL.revokeObjectURL(url);
   }
 
   drop(event: CdkDragDrop<Snippet[]>): void {


### PR DESCRIPTION
…tton display

Implemented the `saveSheet` method in the Sheet component. This method serializes the current list of snippets (id, type, and output properties) into a JSON format and triggers a download of this data as a `snippets.json` file.

The save button in the sheet header is now conditionally rendered using an `@if` block. It will only be visible if there are one or more snippets present in the sheet, enhancing the user interface by only showing relevant actions.