### PR TITLE
Fix: Remove sample data and correct test failures

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,50 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes an additional trace to diminish output verbosity
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/taylored-snippets-web'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadlessCI'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu']
+      }
+    },
+    singleRun: true, // Set to true for CI environments
+    restartOnFileChange: true
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,6 +241,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.0.1.tgz",
       "integrity": "sha512-OU91byvG/WsDDUVmXIJr3/sU89U6g8G8IXrqgVRVPgjXKEQMnUNBlmygD2rMUR5C02g2lGc6s2j0hnOJ/dDNOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "0.2000.1",
         "@angular-devkit/core": "20.0.1",

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -31,52 +31,25 @@ export class App {
   public sideMenuItems: MenuItem[] = [];
 
   constructor() {
-    // Sample Snippets
-    const sampleTextSnippet: Snippet = {
-      id: 0, // ID will be managed by SheetComponent when added, but good for structure
-      type: 'text',
-      getTayloredBlock: () => {
-        const doc = new DOMParser().parseFromString('<xml></xml>', 'application/xml');
-        const textBlock = doc.createElement('text_block');
-        textBlock.textContent = 'Sample text snippet content';
-        doc.documentElement.appendChild(textBlock);
-        return doc;
-      },
-      output: 'Initial text output if any'
-    };
-
-    const sampleComputeSnippet: Snippet = {
-      id: 1,
-      type: 'compute',
-      getTayloredBlock: () => {
-        const doc = new DOMParser().parseFromString('<xml></xml>', 'application/xml');
-        const computeBlock = doc.createElement('compute_block');
-        computeBlock.textContent = 'Sample compute snippet logic';
-        doc.documentElement.appendChild(computeBlock);
-        return doc;
-      },
-      output: 'Initial compute output if any'
-    };
-
     // Sample MenuItems
-    this.sideMenuItems = [
-      {
-        label: 'Menu Item 1 (Text)',
-        snippets: [sampleTextSnippet]
-      },
-      {
-        label: 'Menu Item 2 (Compute)',
-        snippets: [sampleComputeSnippet]
-      },
-      {
-        label: 'Menu Item 3 (Both)',
-        snippets: [sampleTextSnippet, sampleComputeSnippet]
-      },
-      {
-        label: 'Menu Item 4 (Empty)',
-        snippets: []
-      }
-    ];
+    // this.sideMenuItems = [
+    //   {
+    //     label: 'Menu Item 1 (Text)',
+    //     snippets: [sampleTextSnippet]
+    //   },
+    //   {
+    //     label: 'Menu Item 2 (Compute)',
+    //     snippets: [sampleComputeSnippet]
+    //   },
+    //   {
+    //     label: 'Menu Item 3 (Both)',
+    //     snippets: [sampleTextSnippet, sampleComputeSnippet]
+    //   },
+    //   {
+    //     label: 'Menu Item 4 (Empty)',
+    //     snippets: []
+    //   }
+    // ];
   }
 
   public onSnippetsSelected(snippets: Snippet[]) {

--- a/src/app/components/sheet/sheet.spec.ts
+++ b/src/app/components/sheet/sheet.spec.ts
@@ -123,6 +123,9 @@ describe('SheetComponent', () => {
   });
 
   it('should render a save button in the header, correctly aligned', () => {
+    component.addSnippet('text');
+    fixture.detectChanges();
+
     // Check for mat-card-header with the correct class
     const cardHeader = fixture.debugElement.query(By.css('mat-card-header.sheet-card-header'));
     expect(cardHeader).toBeTruthy();
@@ -171,6 +174,8 @@ describe('SheetComponent', () => {
   });
 
   it('should call saveSheet method when save button is clicked', () => {
+    component.addSnippet('text');
+    fixture.detectChanges();
     spyOn(component, 'saveSheet'); // Spy on the saveSheet method
     const saveButton = fixture.debugElement.query(By.css('button[aria-label="Save sheet"]'));
 

--- a/src/app/components/side-menu/side-menu.spec.ts
+++ b/src/app/components/side-menu/side-menu.spec.ts
@@ -38,7 +38,7 @@ describe('SideMenuComponent', () => {
     ];
     component.menuItems = mockMenuItems;
     fixture.detectChanges();
-    const listItems = nativeElement.querySelectorAll('mat-nav-list a');
+    const listItems = nativeElement.querySelectorAll('button[mat-list-item]');
     expect(listItems.length).toBe(2);
     expect(listItems[0].textContent).toContain('Test Label 1');
     expect(listItems[1].textContent).toContain('Test Label 2');
@@ -47,14 +47,14 @@ describe('SideMenuComponent', () => {
   it('should render no items if menuItems is an empty array', () => {
     component.menuItems = [];
     fixture.detectChanges();
-    const listItems = nativeElement.querySelectorAll('mat-nav-list a');
+    const listItems = nativeElement.querySelectorAll('button[mat-list-item]');
     expect(listItems.length).toBe(0);
   });
 
   it('should render no items if menuItems is undefined (component initializes it, but good to check boundary)', () => {
     component.menuItems = [];
     fixture.detectChanges();
-    const listItems = nativeElement.querySelectorAll('mat-nav-list a');
+    const listItems = nativeElement.querySelectorAll('button[mat-list-item]');
     expect(listItems.length).toBe(0);
   });
 
@@ -65,10 +65,10 @@ describe('SideMenuComponent', () => {
     ];
     component.menuItems = mockMenuItems as MenuItem[];
     fixture.detectChanges();
-    const listItems = nativeElement.querySelectorAll('mat-nav-list a');
+    const listItems = nativeElement.querySelectorAll('button[mat-list-item]');
     expect(listItems.length).toBe(2);
     expect(listItems[0].textContent).toContain('Real Label');
-    expect(listItems[1].textContent).toBe('');
+    expect(listItems[1].textContent?.trim()).toBe('');
   });
 
 });


### PR DESCRIPTION
Removes sample data initialization from the App constructor.

Addresses test failures in SheetComponent and SideMenuComponent:

- SheetComponent tests:
  - Modified tests for the save button to ensure a snippet is added before assertions. This accounts for the button's conditional rendering based on snippet presence.
- SideMenuComponent tests:
  - Corrected DOM selectors in tests to accurately find list items (buttons instead of anchor tags).
  - Improved robustness of an assertion for empty labels.

Note: I wasn't able to run the full test suite due to persistent testing environment timeouts. Fixes are based on code analysis.