### PR TITLE
feat(snippet-compute): Integrate with RunnerService for socket.io com…

### DIFF
--- a/src/app/components/snippet-compute/snippet-compute.html
+++ b/src/app/components/snippet-compute/snippet-compute.html
@@ -11,5 +11,5 @@
     <textarea matInput cdkTextareaAutosize [value]="output" readonly cdkAutosizeMinRows="1" cdkAutosizeMaxRows="20">
     </textarea>
   </mat-form-field>
-  <button matButton="elevated" [disabled]="isPlayButtonDisabled">Play</button>
+  <button mat-button color="primary" [disabled]="isPlayButtonDisabled" (click)="tayloredRun()">Play</button>
 </div>


### PR DESCRIPTION
The snippet-compute component has been updated to communicate with runnet.js (the runner) via socket.io through the existing RunnerService.

Key changes:
- Injected RunnerService into SnippetCompute.
- Implemented the `tayloredRun` method, which is triggered when you press the 'Play' button. This method:
    - Ensures a runner is provisioned via RunnerService.
    - Retrieves the XML payload from `getTayloredBlock()`.
    - Sends the payload to the runner using `RunnerService.sendSnippetToRunner()`.
    - Clears previous output on execution.
- Subscribed to `RunnerService.listenForRunnerOutput()` and `RunnerService.listenForRunnerError()` in `ngOnInit` to update the component's `output` property with results or errors from the runner.
- Implemented `ngOnDestroy` to unsubscribe from RxJS subscriptions, preventing memory leaks.
- Added proactive runner provisioning attempt in `ngOnInit`.
- Error messages from provisioning, connection, or execution are displayed in the output area.