### PR TITLE
feat: Implement two-way data flow for snippet execution

### DIFF
--- a/src/app/components/sheet/sheet.ts
+++ b/src/app/components/sheet/sheet.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, inject } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -6,6 +6,7 @@ import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-
 import { CommonModule } from '@angular/common'; // For *ngFor, *ngIf, etc.
 import { SnippetText } from '../snippet-text/snippet-text';
 import { SnippetCompute } from '../snippet-compute/snippet-compute';
+import { RunnerService } from '../../services/runner.service';
 
 export interface Snippet {
   id: number;
@@ -25,6 +26,7 @@ export interface Snippet {
 export class Sheet {
   snippets: Snippet[] = [];
   private nextId = 0;
+  private runnerService = inject(RunnerService);
 
   addSnippet(type: 'text' | 'compute'): void {
     let newSnippet: Snippet;
@@ -33,7 +35,7 @@ export class Sheet {
     if (type === 'text') {
       newSnippet = new SnippetText();
     } else { // type === 'compute'
-      newSnippet = new SnippetCompute();
+      newSnippet = new SnippetCompute(this.runnerService);
     }
 
     newSnippet.id = currentId;
@@ -132,7 +134,7 @@ export class Sheet {
           if (item.type === 'text') {
             newSnippet = new SnippetText();
           } else { // item.type === 'compute'
-            newSnippet = new SnippetCompute();
+            newSnippet = new SnippetCompute(this.runnerService);
           }
 
           newSnippet.id = item.id;

--- a/src/app/components/snippet-compute/snippet-compute.html
+++ b/src/app/components/snippet-compute/snippet-compute.html
@@ -11,5 +11,5 @@
     <textarea matInput cdkTextareaAutosize [value]="output" readonly cdkAutosizeMinRows="1" cdkAutosizeMaxRows="20">
     </textarea>
   </mat-form-field>
-  <button matButton="elevated" [disabled]="isPlayButtonDisabled">Play</button>
+  <button matButton="elevated" [disabled]="isPlayButtonDisabled" (click)="onPlayButtonClick()">Play</button>
 </div>

--- a/src/app/components/snippet-compute/snippet-compute.html
+++ b/src/app/components/snippet-compute/snippet-compute.html
@@ -11,5 +11,5 @@
     <textarea matInput cdkTextareaAutosize [value]="output" readonly cdkAutosizeMinRows="1" cdkAutosizeMaxRows="20">
     </textarea>
   </mat-form-field>
-  <button matButton="elevated" [disabled]="isPlayButtonDisabled" (click)="onPlayButtonClick()">Play</button>
+  <button matButton="elevated" [disabled]="isPlayButtonDisabled || !isRunnerReady" (click)="onPlayButtonClick()">Play</button>
 </div>

--- a/src/app/components/snippet-compute/snippet-compute.ts
+++ b/src/app/components/snippet-compute/snippet-compute.ts
@@ -8,7 +8,7 @@ import { TextFieldModule } from '@angular/cdk/text-field';
 import { MatButtonModule } from '@angular/material/button';
 import { Snippet } from '../sheet/sheet';
 import { SnippetText } from '../snippet-text/snippet-text';
-import { RunnerService } from '../../services/runner.service';
+import { RunnerService, SnippetOutput } from '../../services/runner.service';
 
 export const VALID_INTERPRETERS = [
   'awk',
@@ -45,8 +45,9 @@ export const VALID_INTERPRETERS = [
 })
 export class SnippetCompute implements Snippet, OnInit, OnDestroy {
   type: 'compute' = 'compute';
-  isPlayButtonDisabled: boolean = true;
-  private outputSubscription: Subscription | undefined;
+  isPlayButtonDisabled: boolean = true; // Will be updated based on isRunnerReady and snippet content validity
+  isRunnerReady = false;
+  private subscriptions = new Subscription();
 
   constructor(private runnerService: RunnerService) {}
   
@@ -58,7 +59,7 @@ export class SnippetCompute implements Snippet, OnInit, OnDestroy {
   getTayloredBlock(): XMLDocument {
     const timestamp = Date.now().toString();
     const encodedTimestamp = btoa(timestamp);
-    const xmlString = `<taylored number="${this.id}" compute="${encodedTimestamp}">${this.value}</taylored>`;
+    const xmlString = `<taylored number="${this.id}" compute="${encodedTimestamp}">\n${this.value}\n</taylored>`;
     return new DOMParser().parseFromString(xmlString, "text/xml");
   }
 
@@ -95,22 +96,38 @@ export class SnippetCompute implements Snippet, OnInit, OnDestroy {
     this.updateSnippet.emit(this);
   }
 
-  onPlayButtonClick(): void {
+  async onPlayButtonClick(): Promise<void> {
+    this.output = 'Executing...'; // Provide immediate feedback
     const xmlDoc = this.getTayloredBlock();
     const serializer = new XMLSerializer();
-    const xmlString = serializer.serializeToString(xmlDoc);
-    this.runnerService.sendSnippetToRunner(xmlString);
+    // Using xmlDoc.documentElement to serialize just the <taylored> element and its content
+    const xmlString = serializer.serializeToString(xmlDoc.documentElement);
+    await this.runnerService.sendSnippetToRunner(xmlString);
   }
 
   ngOnInit(): void {
-    this.outputSubscription = this.runnerService.snippetOutput$.subscribe(result => {
-      if (result.id === this.id) {
-        this.output = result.output;
-      }
-    });
+    this.subscriptions.add(
+      this.runnerService.isRunnerReady$.subscribe(isReady => {
+        this.isRunnerReady = isReady;
+        // Future: this.updatePlayButtonState(); (or similar if combined with snippet validity)
+      })
+    );
+
+    this.subscriptions.add(
+      this.runnerService.snippetOutput$.subscribe((result: SnippetOutput) => {
+        if (result.id === this.id) {
+          if (result.error) {
+            this.output = `Error: ${result.error}`;
+          } else if (result.output) {
+            this.output = result.output;
+          }
+          // If neither error nor output is present for this ID, this.output remains unchanged.
+        }
+      })
+    );
   }
 
   ngOnDestroy(): void {
-    this.outputSubscription?.unsubscribe();
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/services/runner.service.ts
+++ b/src/app/services/runner.service.ts
@@ -4,66 +4,75 @@ import { BehaviorSubject, Observable, Subject, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { io, Socket } from 'socket.io-client'; // Using official socket.io-client
 
+export interface SnippetOutput {
+  id: number;
+  output?: string;
+  error?: string;
+}
+
 /**
- * RunnerService is a root-provided Angular service responsible for managing
- * the lifecycle of and communication with a dedicated `runner.js` instance.
+ * RunnerService is an Angular service provided at the root level, responsible for managing
+ * the lifecycle and communication with a dedicated `runner.js` instance.
  * This service handles provisioning (requesting a new runner instance from an
  * orchestrator), deprovisioning (terminating the runner instance), and sending
- * messages or snippets to the runner via Socket.IO. It also listens for
- * output and errors from the runner.
+ * messages or snippets to the runner via Socket.IO. It also listens for output and errors
+ * from the runner.
  */
 @Injectable({
   providedIn: 'root'
 })
 export class RunnerService implements OnDestroy {
-  private orchestratorUrl = 'http://localhost:3001'; // Assuming orchestrator runs here
+  private orchestratorUrl = 'http://localhost:3001'; // Supponendo che l'orchestratore sia in esecuzione qui
 
   private runnerEndpointSubject = new BehaviorSubject<string | null>(null);
   public runnerEndpoint$: Observable<string | null> = this.runnerEndpointSubject.asObservable();
 
-  private snippetOutputSubject = new Subject<{ id: number, output: string }>();
-  public snippetOutput$ = this.snippetOutputSubject.asObservable();
+  private snippetOutputSubject = new Subject<SnippetOutput>();
+  public snippetOutput$: Observable<SnippetOutput> = this.snippetOutputSubject.asObservable();
+
+  private isRunnerReadySubject = new BehaviorSubject<boolean>(false);
+  public isRunnerReady$: Observable<boolean> = this.isRunnerReadySubject.asObservable();
 
   private currentSessionId: string | null = null;
   private runnerSocket: Socket | null = null;
 
   constructor(private http: HttpClient) {
-    // Attempt to deprovision if the window is closed or page is refreshed
+    // Attempt to deprovision if the window is closed or the page is refreshed
     // This is not foolproof but can help in some scenarios.
     window.addEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   private handleBeforeUnload = (event: BeforeUnloadEvent) => {
-    // Standard way to prompt user before leaving, but we use it to deprovision
+    // Standard way to ask for user confirmation before leaving the page, but we use it for deprovisioning
     if (this.currentSessionId) {
       // Note: Most browsers will not guarantee asynchronous operations (like HTTP requests)
-      // in 'beforeunload'. navigator.sendBeacon is preferred for telemetry but not suitable for all POSTs.
-      // This call might not complete successfully.
+      // in 'beforeunload'. navigator.sendBeacon is preferable for telemetry but not suitable for all POSTs.
+      // This call may not complete successfully.
       // A more robust solution involves backend session timeouts for runners.
       this.deprovisionRunnerSync();
     }
   };
 
   // Synchronous deprovisioning attempt for beforeunload
-  // WARNING: This is a best-effort attempt and might be blocked by browsers.
+  // WARNING: This is a "best-effort" attempt and may be blocked by browsers.
   // navigator.sendBeacon would be better if the server could accept GET or application/x-www-form-urlencoded
   private deprovisionRunnerSync(): void {
     if (!this.currentSessionId) return;
     const url = `${this.orchestratorUrl}/api/runner/deprovision`;
     const payload = JSON.stringify({ sessionId: this.currentSessionId });
 
-    // Using sendBeacon if possible (requires specific server handling for content type)
-    // For now, we'll stick to a synchronous XHR which is generally discouraged and may not work.
+    // Using sendBeacon if possible (requires specific content type handling by the server)
+    // For now, we stick to a synchronous XHR which is generally discouraged and may not work.
     try {
         const xhr = new XMLHttpRequest();
         // Opening a POST request synchronously
-        xhr.open('POST', url, false); // false for synchronous
+        xhr.open('POST', url, false); // false per sincrono
         xhr.setRequestHeader('Content-Type', 'application/json');
-        // No good way to handle response or errors here in sync mode
+        // There's no good way to handle the response or errors here in synchronous mode
         xhr.send(payload);
-        console.log('Attempted synchronous deprovision for session:', this.currentSessionId);
+        console.log('Synchronous deprovisioning attempt for session:', this.currentSessionId);
     } catch (e) {
-        console.error('Error attempting synchronous deprovision:', e);
+        console.error('Error during synchronous deprovisioning attempt:', e);
     }
 
     this.currentSessionId = null;
@@ -82,7 +91,7 @@ export class RunnerService implements OnDestroy {
    * programmed to handle them.
    *
    * @param {string} eventName The name of the event to emit. This should
-   *                           correspond to an event listener on the runner.
+   * correspond to an event listener on the runner.
    * @param {any} data The payload to send with the event.
    *
    * @example
@@ -98,12 +107,12 @@ export class RunnerService implements OnDestroy {
   }
 
   /**
-   * Provisions a new runner instance through the orchestrator.
+   * Provisions a new runner instance via the orchestrator.
    * If a runner is already provisioned and connected, it returns the existing endpoint.
    * If a session ID exists but the socket is not connected, it attempts to deprovision
    * the old session before provisioning a new one.
-   * Upon successful provisioning, it initializes a Socket.IO connection to the new runner.
-   * @returns {Promise<string | null>} A promise that resolves with the runner endpoint URL or null if provisioning fails.
+   * After successful provisioning, it initializes a Socket.IO connection to the new runner.
+   * @returns {Promise<string | null>} A promise that resolves with the runner's endpoint URL or null if provisioning fails.
    */
   async provisionRunner(): Promise<string | null> {
     if (this.currentSessionId && this.runnerSocket && this.runnerSocket.connected) {
@@ -111,12 +120,12 @@ export class RunnerService implements OnDestroy {
         return this.runnerEndpointSubject.getValue();
     }
 
-    // If there's a session ID but socket is not connected, try to deprovision first.
+    // If there's a session ID but the socket isn't connected, try deprovisioning first.
     if (this.currentSessionId) {
-        console.warn('Found existing session ID but socket not connected. Attempting to deprovision before reprovisioning.');
+        console.warn('Found existing session ID but socket not connected. Attempting deprovision before new provision.');
         await this.deprovisionRunner().toPromise().catch(err => {
-            console.error('Error during deprovision before reprovisioning. Continuing with provisioning...', err);
-            // Clear local state even if deprovision fails to avoid getting stuck
+            console.error("Error during deprovisioning before new provision. Continuing with provisioning...", err);
+            // Clear local state even if deprovisioning fails to avoid getting stuck
             this.clearRunnerState();
         });
     }
@@ -124,22 +133,22 @@ export class RunnerService implements OnDestroy {
     try {
       // A new session ID will be generated by the orchestrator if not provided,
       // or we can generate one on the client if needed for specific tracking.
-      // For now, let orchestrator handle it or use existing one if any.
+      // For now, let the orchestrator handle it.
       const headers = new HttpHeaders({
         'Content-Type': 'application/json',
-        // 'X-Session-Id': this.currentSessionId || undefined // Example if sending client-generated ID
+        // 'X-Session-Id': this.currentSessionId || undefined // Example if sending a client-generated ID
       });
 
       const response = await this.http.post<{ message: string, endpoint: string, sessionId: string }>(
         `${this.orchestratorUrl}/api/runner/provision`,
-        {}, // Empty body, orchestrator can generate session ID
+        {}, // Body vuoto, l'orchestratore può generare l'ID di sessione
         { headers }
       ).pipe(
         tap(res => console.log('Provisioning response:', res)),
         catchError(err => {
-          console.error('Error during runner provisioning:', err);
+          console.error('Error provisioning runner:', err);
           this.clearRunnerState(); // Clear state on error
-          return throwError(() => new Error(`Failed to provision runner: ${err.message}`));
+          return throwError(() => new Error(`Runner provisioning failed: ${err.message}`));
         })
       ).toPromise();
 
@@ -154,7 +163,7 @@ export class RunnerService implements OnDestroy {
         throw new Error('Invalid response from provisioning server.');
       }
     } catch (error) {
-      console.error('Failed to provision runner:', error);
+      console.error('Runner provisioning failed:', error);
       this.clearRunnerState();
       return null; // Or throw error
     }
@@ -164,41 +173,83 @@ export class RunnerService implements OnDestroy {
     if (this.runnerSocket) {
       this.runnerSocket.disconnect();
     }
-    // Ensure endpoint is valid, e.g., starts with http:// or https://
+    // Ensure the endpoint is valid, e.g., starts with http:// or https://
     if (!endpoint.startsWith('http')) {
-        console.error('Invalid endpoint for socket connection:', endpoint);
-        // Potentially prepend default http if missing, or handle error
-        // For now, we assume it's correct from orchestrator
+        console.error("Invalid endpoint for socket connection:", endpoint);
+        // Potentially prepend http by default if missing, or handle the error
+        // For now, assume it's correct from the orchestrator
     }
     this.runnerSocket = io(endpoint, {
-      reconnectionAttempts: 3,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
       timeout: 10000,
-      // transports: ['websocket'] // Optionally force websocket
+      // transports: ['websocket'] // Opzionalmente forza websocket
     });
 
     this.runnerSocket.on('connect', () => {
       console.log('Socket.IO connected to runner:', endpoint);
+      this.isRunnerReadySubject.next(true);
+      this.setupListeners();
     });
 
     this.runnerSocket.on('disconnect', (reason) => {
       console.log('Socket.IO disconnected from runner:', reason);
-      // Optionally try to reprovision or notify user
+      this.isRunnerReadySubject.next(false);
+      // Optionally try to re-provision or notify the user
       // this.runnerEndpointSubject.next(null); // Consider if this is desired on disconnect
     });
 
     this.runnerSocket.on('connect_error', (error) => {
-      console.error('Socket.IO connection error:', error);
-      this.runnerEndpointSubject.next(null); // Clear endpoint on connection error
-      // Potentially try to deprovision this session as it's unusable
-      if(this.currentSessionId) {
-          this.deprovisionRunner().subscribe({
-              error: err => console.error("Failed to deprovision after connection error", err)
-          });
+      console.error("Socket.IO connection error:", error.message);
+      // Don't deprovision on first error, let the client retry.
+    });
+
+    this.runnerSocket.on('reconnect_failed', () => {
+      console.error("Socket.IO reconnection failed. Deprovisioning runner.");
+      this.isRunnerReadySubject.next(false);
+      this.runnerEndpointSubject.next(null);
+      if (this.currentSessionId) {
+        this.deprovisionRunner().subscribe({
+          error: (err) => console.error(
+              'Deprovisioning failed after reconnection failure',
+              err
+            ),
+        });
       }
     });
   }
 
+  private setupListeners(): void {
+    if (!this.runnerSocket) {
+      console.error('Socket not initialized, cannot set up listeners.');
+      return;
+    }
+
+    // Clear existing listeners before adding new ones to prevent duplicates
+    // if this method could be called multiple times on the same socket instance.
+    // In the current design, it's called once on 'connect'.
+    this.runnerSocket.off('tayloredOutput');
+    this.runnerSocket.off('tayloredError');
+    this.runnerSocket.off('tayloredRunError');
+
+    this.runnerSocket.on('tayloredOutput', (data: SnippetOutput) => {
+      // Ensure data conforms to SnippetOutput
+      this.snippetOutputSubject.next({ id: data.id, output: data.output, error: data.error || undefined });
+    });
+
+    this.runnerSocket.on('tayloredError', (data: SnippetOutput) => {
+       // Ensure data conforms to SnippetOutput
+      this.snippetOutputSubject.next({ id: data.id, error: data.error, output: data.output || undefined });
+    });
+
+    this.runnerSocket.on('tayloredRunError', (data: SnippetOutput) => {
+      // Ensure data conforms to SnippetOutput
+      this.snippetOutputSubject.next({ id: data.id, error: data.error, output: data.output || undefined });
+    });
+  }
+
   private clearRunnerState(): void {
+    this.isRunnerReadySubject.next(false); // Also set runner as not ready
     this.currentSessionId = null;
     this.runnerEndpointSubject.next(null);
     if (this.runnerSocket) {
@@ -209,21 +260,23 @@ export class RunnerService implements OnDestroy {
 
   /**
    * Deprovisions the currently active runner instance.
-   * It sends a request to the orchestrator to terminate the runner associated with the current session ID.
-   * Clears local runner state regardless of whether the orchestrator call succeeds.
+   * Sends a request to the orchestrator to terminate the runner associated with the current session ID.
+   * Clears the local runner state regardless of the success of the orchestrator call.
    * @returns {Observable<any>} An observable that completes when the deprovisioning request is sent,
-   * or an observable of an error if the request fails. If no session is active, it returns
-   * an observable that emits an object with a message 'No active session'.
+   * or an observable of an error if the request fails. If no session is active, returns
+   * an observable that emits an object with a 'No active session' message.
    */
   deprovisionRunner(): Observable<any> {
+    this.isRunnerReadySubject.next(false); // Explicitly set runner as not ready
+
     if (!this.currentSessionId) {
       console.log('No active session to deprovision.');
-      this.clearRunnerState();
+      this.clearRunnerState(); // This will also call isRunnerReadySubject.next(false)
       return new BehaviorSubject({ message: 'No active session' }); // Return an observable
     }
 
     const sessionId = this.currentSessionId;
-    // Clear local state immediately, assuming deprovision will succeed or fail cleanly.
+    // Clear local state immediately, assuming deprovisioning will succeed or fail cleanly.
     this.clearRunnerState();
 
     console.log(`Attempting to deprovision runner for session: ${sessionId}`);
@@ -233,8 +286,8 @@ export class RunnerService implements OnDestroy {
       tap(() => console.log(`Deprovisioning request sent for session: ${sessionId}`)),
       catchError(err => {
         console.error(`Error deprovisioning runner for session ${sessionId}:`, err);
-        // Even if deprovision fails on server, local state is already cleared.
-        return throwError(() => new Error(`Failed to deprovision runner: ${err.message}`));
+        // Even if deprovisioning fails on the server, local state has already been cleared.
+        return throwError(() => new Error(`Runner deprovisioning failed: ${err.message}`));
       })
     );
   }
@@ -242,75 +295,46 @@ export class RunnerService implements OnDestroy {
   /**
    * Sends snippet data (XML) to the connected runner for execution.
    * The runner should be set up to listen for the 'tayloredRun' event.
-   * @param {string} xmlData The XML string representing the snippet to be executed.
+   * @param {string} xmlData The XML string representing the snippet to execute.
    */
-  sendSnippetToRunner(xmlData: string): void {
+  public async sendSnippetToRunner(xmlData: string): Promise<void> {
+    if (!this.isRunnerReadySubject.getValue()) {
+      console.warn('Runner not ready. Attempting to provision a new one...');
+      try {
+        await this.provisionRunner();
+        // After successful provisioning, isRunnerReadySubject should be true via initializeSocket's 'connect' event.
+        // However, if provisionRunner resolves but the socket doesn't connect immediately,
+        // isRunnerReadySubject might still be false here. The check below will handle it.
+      } catch (error) {
+        console.error("Re-provisioning failed. Cannot execute snippet.", error);
+        return;
+      }
+    }
+
     if (this.runnerSocket && this.runnerSocket.connected) {
       this.runnerSocket.emit('tayloredRun', { body: xmlData });
       console.log('Snippet sent to runner via Socket.IO');
     } else {
-      console.error('Runner socket not connected. Cannot send snippet.');
-      // Optionally try to provision again or notify user
-      // this.provisionRunner(); // Be careful with automatic re-provisioning loops
+      // This case handles if provisioning was attempted but the socket is not yet connected.
+      console.error("Runner socket not connected. Cannot send snippet. Provisioning may have failed or socket connection is delayed.");
     }
-  }
-
-  /**
-   * Listens for 'tayloredOutput' events from the runner.
-   * These events are expected to carry the output or results of snippet execution.
-   * @returns {Observable<any>} An observable that emits data received from the 'tayloredOutput' event.
-   * Throws an error if the socket is not initialized.
-   */
-  listenForRunnerOutput(): void {
-    if (!this.runnerSocket) {
-      // Return an empty observable or throw error if socket not initialized
-      // Consider logging an error or handling this state appropriately
-      console.error('Runner socket not initialized for listening to output.');
-      return;
-    }
-    this.runnerSocket.on('tayloredOutput', (data: { id: number, output: string }) => {
-      this.snippetOutputSubject.next(data);
-    });
-    // Note: No direct way to clean up this specific listener with socket.io v2/v3 client
-    // if you need to stop listening to just this, you might need `this.runnerSocket.off('tayloredOutput')`
-    // called explicitly when the service is destroyed or when no longer needed.
-    // However, socket disconnect on ngOnDestroy will clean up all listeners.
-  }
-
-  /**
-   * Listens for 'tayloredRunError' events from the runner.
-   * These events are expected to carry error information from snippet execution.
-   * @returns {Observable<any>} An observable that emits data received from the 'tayloredRunError' event.
-   * Throws an error if the socket is not initialized.
-   */
-  listenForRunnerError(): Observable<any> {
-    if (!this.runnerSocket) {
-      return throwError(() => new Error('Runner socket not initialized for listening to errors.'));
-    }
-    return new Observable(observer => {
-      this.runnerSocket?.on('tayloredRunError', (data) => {
-        observer.next(data);
-      });
-      // Cleanup when unsubscribed
-      return () => this.runnerSocket?.off('tayloredRunError');
-    });
   }
 
   /**
    * Lifecycle hook that cleans up when the service is destroyed.
    * This is crucial for deprovisioning the runner to free up resources.
-   * It removes the 'beforeunload' event listener and attempts to deprovision the runner.
+   * Removes the 'beforeunload' event listener and attempts to deprovision the runner.
    */
   ngOnDestroy(): void {
-    console.log('RunnerService ngOnDestroy called. Attempting deprovision.');
-    // Remove the event listener to prevent memory leaks
+    console.log('RunnerService ngOnDestroy called. Attempting deprovisioning.');
+    // Remove event listener to prevent memory leaks
     window.removeEventListener('beforeunload', this.handleBeforeUnload);
 
-    // Use the async deprovision and subscribe to it.
-    // ngOnDestroy can handle async if needed, but completion isn't guaranteed if app is force-closed.
+    // Use asynchronous deprovisioning and subscribe.
+    // ngOnDestroy can handle async if needed, but completion is not guaranteed if the app is forcibly closed.
     if (this.currentSessionId) {
       this.deprovisionRunner().subscribe({
-        next: () => console.log('Deprovisioned runner on service destroy.'),
+        next: () => console.log('Runner deprovisioned on service destroy.'),
         error: (err) => console.error('Error deprovisioning runner on service destroy:', err)
       });
     }

--- a/src/runner/Dockerfile
+++ b/src/runner/Dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache \
     tcsh \
     curl \
     gnupg \
-    ca-certificates
+    ca-certificates \
+    git
 
 # Installa i linguaggi di scripting e gli ambienti di runtime usando apk.
 # Ho cambiato 'lua5.4' a 'lua' e 'R' a 'R' (il nome del pacchetto è R).

--- a/src/runner/runner.js
+++ b/src/runner/runner.js
@@ -17,68 +17,85 @@ const io = new Server(httpServer, {
 });
 
 const PORT = process.env.PORT || 3000;
+console.log(`[Info] Runner service starting on port ${PORT}`);
+
 io.on('connection', (socket) => {
+  console.log(`[Connection] New client connected: ${socket.id}`);
 
   socket.on('disconnect', () => {
+    console.log(`[Connection] Client disconnected: ${socket.id}`);
   });
 
   socket.on('tayloredRun', async (xmlDataRequest) => {
+    console.log('[tayloredRun] Received tayloredRun event.');
     const xmlData = xmlDataRequest.body;
+    
     if (typeof xmlData !== 'string' || xmlData.trim() === '') {
-      socket.emit('tayloredRunError', { error: 'Invalid XML data: must be a non-empty string.' });
-      return;
+      console.error('[tayloredRun] Invalid XML data received.');
+      return socket.emit('tayloredRunError', { error: 'Invalid XML data: must be a non-empty string.' });
     }
+    console.log('[tayloredRun] Snippet XML received:\n', xmlData);
+
     const blockRegex = /[^\n]*?<taylored\s+number=["'](\d+)["'](?:\s+compute=["']([^"']*)["'])?>([\s\S]*?)[^\n]*?<\/taylored>/g;
     const matches = [...xmlData.matchAll(blockRegex)];
 
-    // Assuming the first match is the relevant one for the ID
     let numberValue = null;
     if (matches.length > 0) {
-      const firstMatch = matches[0];
-      numberValue = firstMatch[1];
-      // const computeValue = firstMatch[2]; // computeValue not used in this modification
-      // const innerContent = firstMatch[3].trim(); // innerContent not used in this modification
-    }
-
-    // If no numberValue could be extracted, it's an issue with the input or regex
-    if (numberValue === null) {
-      socket.emit('tayloredRunError', { error: 'Could not extract snippet ID (number) from XML data.' });
-      return;
+      numberValue = matches[0][1];
+      console.log(`[tayloredRun] Extracted Snippet ID: ${numberValue}`);
+    } else {
+      console.error('[tayloredRun] Could not extract snippet ID from XML.');
+      return socket.emit('tayloredRunError', { error: 'Could not extract snippet ID (number) from XML data.' });
     }
 
     let tempDir;
     try {
       tempDir = tmp.dirSync({ unsafeCleanup: true });
       const tempDirPath = tempDir.name;
+      
       const git = simpleGit(tempDirPath);
       await git.init(['--initial-branch=main']);
+      await git.addConfig('user.name', 'Taylored Runner');
+      await git.addConfig('user.email', 'bot@taylored.run');
+      
       const xmlFilePath = path.join(tempDirPath, 'runner.xml');
       await fs.writeFile(xmlFilePath, xmlData);
       await git.add(xmlFilePath);
       await git.commit('Add runner.xml');
+      
       const tayloredProcess = spawn('npx', ['taylored', '--automatic', 'xml', 'main'], { cwd: tempDirPath });
+      console.log(`[Debug] Spawning command: npx taylored --automatic xml main in ${tempDirPath}`);
 
       tayloredProcess.stdout.on('data', (data) => {
-        socket.emit('tayloredOutput', { id: parseInt(numberValue, 10), output: data.toString() });
+        const output = data.toString();
+        console.log(`[tayloredProcess stdout] Streaming output for ID ${numberValue}:\n`, output);
+        socket.emit('tayloredOutput', { id: parseInt(numberValue, 10), output: output });
       });
 
       tayloredProcess.stderr.on('data', (data) => {
-        socket.emit('tayloredError', { error: data.toString() });
+        const errorOutput = data.toString();
+        console.error(`[tayloredProcess stderr] Streaming error for ID ${numberValue}:\n`, errorOutput);
+        socket.emit('tayloredError', { id: parseInt(numberValue, 10), error: errorOutput });
       });
 
       tayloredProcess.on('error', (error) => {
-        socket.emit('tayloredRunError', { error: `Execution failed: ${error.message}` });
+        console.error('[tayloredProcess error]', error);
+        socket.emit('tayloredRunError', { id: numberValue ? parseInt(numberValue, 10) : null, error: `Execution failed: ${error.message}` });
       });
 
       tayloredProcess.on('close', (code) => {
-        console.log(`Command finished with code ${code}`);
+        console.log(`[tayloredProcess] Command finished for ID ${numberValue} with code ${code}`);
       });
+
     } catch (err) {
-      socket.emit('tayloredRunError', { error: `Server-side error: ${err.message}` });
+      console.error('[Server Error]', err);
+      socket.emit('tayloredRunError', { id: numberValue ? parseInt(numberValue, 10) : null, error: `Server-side error: ${err.message}` });
     } finally {
       // tempDir cleanup is handled by tmp.dirSync with unsafeCleanup: true
     }
   });
 });
+
 httpServer.listen(PORT, () => {
+  console.log(`[Info] Runner is listening on port ${PORT}`);
 });


### PR DESCRIPTION
This commit implements the full two-way communication between the snippet-compute component and the RunnerService.

Key changes:

- SnippetCompute now sends snippet data to RunnerService when the 'Play' button is clicked.
- RunnerService uses an RxJS Subject to broadcast execution results (output) received from the runner.
- Runner.js (backend) has been updated to include the snippet ID in the 'tayloredOutput' event, allowing the correct SnippetCompute instance to receive its specific output.
- SnippetCompute subscribes to the RunnerService's output observable in ngOnInit and filters results based on its own ID.
- Implemented ngOnDestroy in SnippetCompute to unsubscribe from the observable, preventing memory leaks.

This enables each snippet-compute component to independently send code to the runner and receive its specific output, which is then displayed in the UI.