### PR TITLE
feat: Implement REUSE_RUNNER_MODE and new docker-compose profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,7 @@ Before you start, make sure you have the following installed:
 
 ## Building the Runner Image
 
-Before launching the application, you need to build the Docker image for the runner service. The orchestration service will use it to create runner instances on demand.
-
-Navigate to the runner directory and run the build command:
-```bash
-cd src/orchestrator
-docker build -t runner-image .
-```
+The `runner-image`, which is used by the orchestrator to create runner instances, is automatically built by Docker Compose when you launch the application using either the `multitenant` or `singletenant` profile. This is handled by the `runner-builder` service defined in the `docker-compose.yml` file.
 
 ## How to Launch the Application
 
@@ -54,13 +48,13 @@ This mode is ideal for production or for tests that require complete session iso
 
 1.  **Start the services with the `multitenant` profile:**
     ```bash
-    docker compose build runner-standalone
     docker-compose --profile multitenant up --build
     ```
 
 2.  This command will start the following services:
-    * `frontend`: The Angular application, accessible at `http://localhost:80`.
-    * `orchestrator`: The Node.js service that listens on port `3001` and manages the runners.
+    * `frontend-multitenant`: The Angular application, accessible at `http://localhost:80`.
+    * `orchestrator-multitenant`: The Node.js service that listens on port `3001` and manages the runners in a multi-tenant fashion (REUSE_RUNNER_MODE=false).
+    * `runner-builder`: This service builds the `runner-image` and exits.
 
 ### Singletenant Mode
 
@@ -72,8 +66,9 @@ This mode is simpler and suitable for local development. It uses a single `runne
     ```
 
 2.  This command will start the following services:
-    * `frontend`: The Angular application, accessible at `http://localhost:80`.
-    * `runner-standalone`: The single runner service listening on port `3000`.
+    * `frontend-singletenant`: The Angular application, accessible at `http://localhost:80`.
+    * `orchestrator-singletenant`: The Node.js service that listens on port `3001` and uses a single, shared runner instance (REUSE_RUNNER_MODE=true).
+    * `runner-builder`: This service builds the `runner-image` and exits.
 
 Once the services are running, you can access the application by opening your browser and navigating to `http://localhost:80`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,48 +5,60 @@ x-frontend-common: &frontend-common
   ports:
     - "80:80"
 
+x-orchestrator-common: &orchestrator-common
+  build:
+    context: ./src/orchestrator
+    dockerfile: ./Dockerfile
+  ports:
+    - "3001:3001"
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+  command: node orchestrator.js
+  # depends_on will be added specifically for each profile
+
 services:
   # --- SINGLETENANT PROFILE SERVICES ---
   frontend-singletenant:
     <<: *frontend-common
     profiles: ["singletenant"]
     depends_on:
-      - runner-standalone
+      orchestrator-singletenant:
+        condition: service_started
 
   # --- MULTITENANT PROFILE SERVICES ---
   frontend-multitenant:
     <<: *frontend-common
     profiles: ["multitenant"]
     depends_on:
-      - orchestrator
+      orchestrator-multitenant:
+        condition: service_started
 
-  orchestrator:
-    build:
-      context: ./src/orchestrator
-      dockerfile: ./Dockerfile
-    ports:
-      - "3001:3001"
-    # Mount the Docker socket to allow the orchestrator to manage other containers.
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+  orchestrator-multitenant:
+    <<: *orchestrator-common
     environment:
       - NODE_ENV=development
-    command: node orchestrator.js
+      - REUSE_RUNNER_MODE=false
     profiles: ["multitenant"]
-    # The orchestrator's dependency is on the 'runner-image' IMAGE being available, not on a running container.
+    depends_on:
+      runner-builder:
+        condition: service_started
+
+  orchestrator-singletenant:
+    <<: *orchestrator-common
+    environment:
+      - NODE_ENV=development
+      - REUSE_RUNNER_MODE=true
+    profiles: ["singletenant"]
+    depends_on:
+      runner-builder:
+        condition: service_started
 
   # --- RUNNER SERVICE ---
-  runner-standalone:
+  runner-builder:
     build:
       context: ./src/runner
       dockerfile: ./Dockerfile
-    ports:
-      - "3000:3000"
     # This image name is crucial. The orchestrator will use it to start new runners.
     image: runner-image
-    environment:
-      - PORT=3000
-    command: node runner.js
-    # For the 'multitenant' profile, only its image will exist, ready to be used by the orchestrator.
-    profiles: ["singletenant"]
+    # No profiles, ports, environment, or command for a builder service
 


### PR DESCRIPTION
This commit introduces a new mechanism for runner provisioning controlled by the REUSE_RUNNER_MODE environment variable and restructures the docker-compose.yml to support distinct singletenant and multitenant profiles with corresponding orchestrator configurations.

Changes include:

1.  **`docker-compose.yml`:**
    *   I defined `orchestrator-singletenant` and `orchestrator-multitenant`
        services, replacing the single `orchestrator`.
    *   `orchestrator-singletenant` runs with `REUSE_RUNNER_MODE=true`.
    *   `orchestrator-multitenant` runs with `REUSE_RUNNER_MODE=false`.
    *   I renamed `runner-standalone` to `runner-builder`, which now only
        builds the `runner-image` and is depended upon by both
        orchestrator services.
    *   I updated frontend services (`frontend-singletenant`,
        `frontend-multitenant`) to depend on their respective
        orchestrators.
    *   I standardized `depends_on` syntax.

2.  **`src/orchestrator/orchestrator.js`:**
    *   I implemented logic to read `REUSE_RUNNER_MODE` from `process.env`.
    *   If `REUSE_RUNNER_MODE` is true:
        *   The first provision request creates a singleton runner instance.
        *   Subsequent provision requests return the existing singleton.
        *   Deprovision requests are ignored to protect the singleton.
    *   I added logging to indicate the active mode on startup.
    *   I ensured `sessionId` is included in `runnerDetails`.

3.  **`README.md`:**
    *   I updated instructions for building and launching the application
        to reflect the new docker-compose profiles and service names.
    *   I clarified that `runner-image` is built automatically.
    *   I described the behavior of the `orchestrator-singletenant`
        (shared runner) and `orchestrator-multitenant` (isolated runners).